### PR TITLE
Don't include invalid query string

### DIFF
--- a/src/test/java/org/embulk/filter/query_string/TestQueryStringFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/query_string/TestQueryStringFilterPlugin.java
@@ -95,7 +95,7 @@ public class TestQueryStringFilterPlugin
                 TestPageBuilderReader.MockPageOutput mockPageOutput = new TestPageBuilderReader.MockPageOutput();
                 PageOutput pageOutput = plugin.open(taskSource, inputSchema, outputSchema, mockPageOutput);
 
-                List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), inputSchema, "before", "/path?q1=one&q2=2", "after");
+                List<Page> pages = PageTestUtils.buildPage(runtime.getBufferAllocator(), inputSchema, "before", "/path?q1=one&q2=2#fragment", "after");
                 for (Page page : pages) {
                     pageOutput.add(page);
                 }


### PR DESCRIPTION
Strict checking for query string. This fixes #1 
## NOTE

<s>This change make a shebang url such as `/#!/ajax?field1=1&field2=2` as invalid URL.</s>
